### PR TITLE
Add financial snapshot, burn rate tools and enriched helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,83 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@vitest/coverage-v8": "^3.0.0",
         "typescript": "^5.0.0",
         "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -475,12 +550,72 @@
         "hono": "^4"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.26.0",
@@ -520,6 +655,17 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -907,6 +1053,40 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1068,6 +1248,32 @@
         }
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1077,6 +1283,25 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
+      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -1094,6 +1319,13 @@
         "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -1117,6 +1349,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/bytes": {
@@ -1201,6 +1443,26 @@
       "engines": {
         "node": ">= 16"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1344,10 +1606,24 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
@@ -1651,6 +1927,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -1767,6 +2060,28 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -1777,6 +2092,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/has-symbols": {
@@ -1826,6 +2151,13 @@
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -1887,6 +2219,16 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -1898,6 +2240,76 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jose": {
       "version": "6.1.3",
@@ -1934,6 +2346,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -1942,6 +2361,34 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1997,6 +2444,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -2075,6 +2548,13 @@
         "wrappy": "1"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -2091,6 +2571,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {
@@ -2312,6 +2809,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -2463,6 +2973,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2496,6 +3019,110 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-literal": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
@@ -2507,6 +3134,34 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tinybench": {
@@ -2830,6 +3485,104 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "tsc",
     "prepare": "tsc",
     "start": "node build/index.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.17.5",
@@ -20,6 +21,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "typescript": "^5.0.0",
+    "@vitest/coverage-v8": "^3.0.0",
     "vitest": "^3.0.0"
   }
 }

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,0 +1,492 @@
+import { describe, it, expect } from "vitest";
+import {
+  getMonthRange,
+  getCurrentYTDRange,
+  getCurrentMonthRange,
+  buildFinancialSnapshot,
+  computeBurnRate,
+  enrichTransactions,
+  analyzeAging,
+  analyzeContracts,
+} from "./helpers.js";
+
+// --- Date helpers ---
+
+describe("getMonthRange", () => {
+  const ref = new Date(2026, 1, 8); // Feb 8, 2026
+
+  it("returns current month range for monthsAgo=0", () => {
+    const r = getMonthRange(0, ref);
+    expect(r.dateFrom).toBe("2026-02-01");
+    expect(r.dateTo).toBe("2026-02-28");
+  });
+
+  it("returns last month range for monthsAgo=1", () => {
+    const r = getMonthRange(1, ref);
+    expect(r.dateFrom).toBe("2026-01-01");
+    expect(r.dateTo).toBe("2026-01-31");
+  });
+
+  it("returns 3 months ago correctly", () => {
+    const r = getMonthRange(3, ref);
+    expect(r.dateFrom).toBe("2025-11-01");
+    expect(r.dateTo).toBe("2025-11-30");
+  });
+});
+
+describe("getCurrentYTDRange", () => {
+  it("returns Jan 1 through today", () => {
+    const ref = new Date(2026, 1, 8);
+    const r = getCurrentYTDRange(ref);
+    expect(r.dateFrom).toBe("2026-01-01");
+    expect(r.dateTo).toBe("2026-02-08");
+  });
+});
+
+describe("getCurrentMonthRange", () => {
+  it("returns first of month through today", () => {
+    const ref = new Date(2026, 1, 8);
+    const r = getCurrentMonthRange(ref);
+    expect(r.dateFrom).toBe("2026-02-01");
+    expect(r.dateTo).toBe("2026-02-08");
+  });
+});
+
+// --- Financial Snapshot ---
+
+describe("buildFinancialSnapshot", () => {
+  const incomeStatement = [
+    { name: "Revenue", total: 500000 },
+    { name: "Cost of Goods Sold", total: 200000 },
+    { name: "Operating Expenses", total: 350000 },
+    { name: "Net Income", total: 150000 },
+  ];
+
+  const balanceSheet = {
+    "Cash and Cash Equivalents": { total: 800000 },
+    "Total Current Assets": { total: 1200000 },
+    "Total Current Liabilities": { total: 400000 },
+  };
+
+  const cashFlow = {}; // not heavily used yet
+
+  it("extracts key financial metrics", () => {
+    const snap = buildFinancialSnapshot(incomeStatement, balanceSheet, cashFlow, "Jan 2026");
+    expect(snap.period).toBe("Jan 2026");
+    expect(snap.revenue).toBe(500000);
+    expect(snap.netIncome).toBe(150000);
+    expect(snap.cashPosition).toBe(800000);
+  });
+
+  it("computes gross margin correctly", () => {
+    const snap = buildFinancialSnapshot(incomeStatement, balanceSheet, cashFlow, "Jan 2026");
+    // gross profit = 500000 - 200000 = 300000, margin = 60%
+    expect(snap.grossMarginPercent).toBe(60);
+  });
+
+  it("computes net margin correctly", () => {
+    const snap = buildFinancialSnapshot(incomeStatement, balanceSheet, cashFlow, "Jan 2026");
+    // net margin = 150000 / 500000 = 30%
+    expect(snap.netMarginPercent).toBe(30);
+  });
+
+  it("computes current ratio", () => {
+    const snap = buildFinancialSnapshot(incomeStatement, balanceSheet, cashFlow, "Jan 2026");
+    // 1200000 / 400000 = 3.0
+    expect(snap.currentRatio).toBe(3);
+  });
+
+  it("handles empty data gracefully", () => {
+    const snap = buildFinancialSnapshot(null, null, null, "Empty");
+    expect(snap.revenue).toBe(0);
+    expect(snap.netIncome).toBe(0);
+    expect(snap.cashPosition).toBeNull();
+    expect(snap.grossMarginPercent).toBeNull();
+    expect(snap.currentRatio).toBeNull();
+  });
+
+  it("handles nested section format", () => {
+    const nested = {
+      revenue: [{ amount: 100000 }, { amount: 50000 }],
+    };
+    const snap = buildFinancialSnapshot(nested, {}, {}, "Nested");
+    // extractTotal should find "revenue" key and sum rows
+    expect(snap.revenue).toBe(150000);
+  });
+});
+
+  it("handles array with nested children/rows", () => {
+    // This tests the recursive branch in extractTotal (lines 320-324)
+    const data = [
+      {
+        name: "Operating",
+        children: [
+          { name: "Revenue", total: 200000 },
+        ],
+      },
+    ];
+    const snap = buildFinancialSnapshot(data, {}, {}, "Nested Array");
+    expect(snap.revenue).toBe(200000);
+  });
+
+  it("handles label/title/account_name aliases in extractTotal", () => {
+    const data = [
+      { label: "Sales Revenue", amount: 75000 },
+      { title: "Total Expenses", value: 50000 },
+    ];
+    const snap = buildFinancialSnapshot(data, {}, {}, "Aliases");
+    expect(snap.revenue).toBe(75000);
+    expect(snap.expenses).toBe(50000);
+  });
+
+  it("handles object with number value directly", () => {
+    const data = { revenue: 300000, expense: 180000 };
+    const snap = buildFinancialSnapshot(data, {}, {}, "Direct");
+    expect(snap.revenue).toBe(300000);
+    expect(snap.expenses).toBe(180000);
+  });
+
+  it("handles object with .amount sub-property", () => {
+    const data = { revenue: { amount: 400000 } };
+    const snap = buildFinancialSnapshot(data, {}, {}, "Amount");
+    expect(snap.revenue).toBe(400000);
+  });
+
+  it("recurses into nested objects", () => {
+    const bs = {
+      assets: {
+        current: {
+          "Cash and Cash Equivalents": 250000,
+        },
+      },
+    };
+    const snap = buildFinancialSnapshot([], bs, {}, "Deep");
+    expect(snap.cashPosition).toBe(250000);
+  });
+
+// --- Burn Rate ---
+
+describe("computeBurnRate", () => {
+  const months = [
+    { label: "Nov 2025", data: [{ name: "Revenue", total: 80000 }, { name: "Expenses", total: 100000 }] },
+    { label: "Dec 2025", data: [{ name: "Revenue", total: 85000 }, { name: "Expenses", total: 105000 }] },
+    { label: "Jan 2026", data: [{ name: "Revenue", total: 90000 }, { name: "Expenses", total: 110000 }] },
+  ];
+
+  const balanceSheet = { "Cash": { total: 500000 } };
+
+  it("computes average burn rate", () => {
+    const result = computeBurnRate(months, balanceSheet);
+    // Burns: 20000, 20000, 20000 → avg 20000
+    expect(result.monthlyBurnAvg).toBe(20000);
+  });
+
+  it("computes runway from cash and burn", () => {
+    const result = computeBurnRate(months, balanceSheet);
+    // 500000 / 20000 = 25 months
+    expect(result.runwayMonths).toBe(25);
+  });
+
+  it("detects stable trend when burns are equal", () => {
+    const result = computeBurnRate(months, balanceSheet);
+    expect(result.trend).toBe("stable");
+  });
+
+  it("detects increasing burn", () => {
+    const increasing = [
+      { label: "M1", data: [{ name: "Revenue", total: 50000 }, { name: "Expenses", total: 60000 }] },
+      { label: "M2", data: [{ name: "Revenue", total: 50000 }, { name: "Expenses", total: 70000 }] },
+      { label: "M3", data: [{ name: "Revenue", total: 50000 }, { name: "Expenses", total: 80000 }] },
+      { label: "M4", data: [{ name: "Revenue", total: 50000 }, { name: "Expenses", total: 90000 }] },
+    ];
+    const result = computeBurnRate(increasing, balanceSheet);
+    expect(result.trend).toBe("increasing");
+  });
+
+  it("detects decreasing burn", () => {
+    const decreasing = [
+      { label: "M1", data: [{ name: "Revenue", total: 50000 }, { name: "Expenses", total: 90000 }] },
+      { label: "M2", data: [{ name: "Revenue", total: 50000 }, { name: "Expenses", total: 80000 }] },
+      { label: "M3", data: [{ name: "Revenue", total: 50000 }, { name: "Expenses", total: 70000 }] },
+      { label: "M4", data: [{ name: "Revenue", total: 50000 }, { name: "Expenses", total: 60000 }] },
+    ];
+    const result = computeBurnRate(decreasing, balanceSheet);
+    expect(result.trend).toBe("decreasing");
+  });
+
+  it("handles empty months array", () => {
+    const result = computeBurnRate([], balanceSheet);
+    expect(result.monthlyBurnAvg).toBe(0);
+    expect(result.monthlyBurns).toHaveLength(0);
+    expect(result.runwayMonths).toBeNull();
+  });
+});
+
+// --- Transaction enrichment ---
+
+describe("enrichTransactions", () => {
+  const txns = [
+    {
+      id: 1,
+      date: "2026-01-15",
+      description: "Office rent",
+      account_name: "Rent Expense",
+      account_type: "Expense",
+      vendor_name: "Landlord Inc",
+      debit_amount: 5000,
+      credit_amount: 0,
+    },
+    {
+      id: 2,
+      date: "2026-01-16",
+      description: "Client payment",
+      account_name: "Accounts Receivable",
+      account_type: "Asset",
+      vendor_name: null,
+      debit_amount: 0,
+      credit_amount: 15000,
+    },
+    {
+      id: 3,
+      date: "2026-01-17",
+      description: "Software subscription",
+      account_name: "Software Expense",
+      account_type: "Expense",
+      vendor_name: "SaaS Co",
+      debit_amount: 200,
+      credit_amount: 0,
+    },
+  ];
+
+  it("computes total debits and credits", () => {
+    const result = enrichTransactions(txns);
+    expect(result.totalDebits).toBe(5200);
+    expect(result.totalCredits).toBe(15000);
+  });
+
+  it("counts transactions", () => {
+    const result = enrichTransactions(txns);
+    expect(result.totalTransactions).toBe(3);
+  });
+
+  it("groups by account type", () => {
+    const result = enrichTransactions(txns);
+    expect(result.byAccountType["Expense"].count).toBe(2);
+    expect(result.byAccountType["Expense"].debits).toBe(5200);
+    expect(result.byAccountType["Asset"].count).toBe(1);
+    expect(result.byAccountType["Asset"].credits).toBe(15000);
+  });
+
+  it("shapes individual transactions", () => {
+    const result = enrichTransactions(txns);
+    expect(result.transactions[0].accountName).toBe("Rent Expense");
+    expect(result.transactions[0].vendorName).toBe("Landlord Inc");
+    expect(result.transactions[0].debit).toBe(5000);
+  });
+
+  it("handles empty array", () => {
+    const result = enrichTransactions([]);
+    expect(result.totalTransactions).toBe(0);
+    expect(result.totalDebits).toBe(0);
+    expect(result.totalCredits).toBe(0);
+  });
+
+  it("handles alternate field names (camelCase)", () => {
+    const result = enrichTransactions([
+      {
+        id: 10,
+        transaction_date: "2026-02-01",
+        memo: "Memo text",
+        accountName: "Cash",
+        accountType: "Asset",
+        vendorName: "V1",
+        departmentName: "D1",
+        debit: 1000,
+        credit: 0,
+      },
+    ]);
+    expect(result.transactions[0].date).toBe("2026-02-01");
+    expect(result.transactions[0].description).toBe("Memo text");
+    expect(result.transactions[0].accountName).toBe("Cash");
+    expect(result.transactions[0].vendorName).toBe("V1");
+    expect(result.transactions[0].departmentName).toBe("D1");
+  });
+});
+
+// --- Aging analysis ---
+
+describe("analyzeAging", () => {
+  const agingData = [
+    { vendor_name: "Vendor A", amount: 10000, days_outstanding: 15, aging_bucket: "0-30" },
+    { vendor_name: "Vendor B", amount: 5000, days_outstanding: 45, aging_bucket: "31-60" },
+    { vendor_name: "Vendor C", amount: 8000, days_outstanding: 95, aging_bucket: "90+" },
+    { vendor_name: "Vendor D", amount: 3000, days_outstanding: 100, aging_bucket: "90+" },
+  ];
+
+  it("computes total outstanding", () => {
+    const result = analyzeAging(agingData, "ap");
+    expect(result.totalOutstanding).toBe(26000);
+  });
+
+  it("groups into buckets", () => {
+    const result = analyzeAging(agingData, "ap");
+    expect(result.buckets["0-30"].count).toBe(1);
+    expect(result.buckets["0-30"].total).toBe(10000);
+    expect(result.buckets["90+"].count).toBe(2);
+    expect(result.buckets["90+"].total).toBe(11000);
+  });
+
+  it("identifies 90+ day critical items", () => {
+    const result = analyzeAging(agingData, "ap");
+    expect(result.criticalItems).toHaveLength(2);
+    expect(result.criticalItems[0].name).toBe("Vendor C");
+    expect(result.criticalItems[1].name).toBe("Vendor D");
+  });
+
+  it("sets aging type correctly", () => {
+    expect(analyzeAging(agingData, "ap").type).toBe("ap");
+    expect(analyzeAging(agingData, "ar").type).toBe("ar");
+    expect(analyzeAging(agingData).type).toBe("combined");
+  });
+
+  it("handles empty data", () => {
+    const result = analyzeAging([]);
+    expect(result.totalOutstanding).toBe(0);
+    expect(result.criticalItems).toHaveLength(0);
+  });
+
+  it("handles alternate field names (balance, bucket, customer_name)", () => {
+    const data = [
+      { customer_name: "Cust A", balance: 7000, days: 50, bucket: "31-60", reference: "INV-1", due_date: "2026-01-01" },
+    ];
+    const result = analyzeAging(data, "ar");
+    expect(result.items[0].name).toBe("Cust A");
+    expect(result.items[0].amount).toBe(7000);
+    expect(result.items[0].invoiceNumber).toBe("INV-1");
+    expect(result.items[0].dueDate).toBe("2026-01-01");
+  });
+
+  it("auto-categorizes when no bucket field exists", () => {
+    const data = [
+      { name: "X", amount: 1000, days_outstanding: 5 },
+      { name: "Y", amount: 2000, days_outstanding: 35 },
+      { name: "Z", amount: 3000, days_outstanding: 95 },
+    ];
+    const result = analyzeAging(data);
+    expect(result.buckets["0-30"].total).toBe(1000);
+    expect(result.buckets["31-60"].total).toBe(2000);
+    expect(result.buckets["90+"].total).toBe(3000);
+  });
+});
+
+// --- Contract analysis ---
+
+describe("analyzeContracts", () => {
+  const contracts = [
+    {
+      id: 1,
+      name: "Project Alpha",
+      client_name: "Client A",
+      status: "active",
+      total_revenue: 100000,
+      total_billed: 60000,
+      total_unbilled: 40000,
+      start_date: "2025-06-01",
+      end_date: "2026-06-01",
+    },
+    {
+      id: 2,
+      name: "Project Beta",
+      client_name: "Client B",
+      status: "active",
+      total_revenue: 50000,
+      total_billed: 50000,
+      total_unbilled: 0,
+      start_date: "2025-01-01",
+      end_date: "2025-12-31",
+    },
+    {
+      id: 3,
+      name: "Project Gamma",
+      client_name: "Client C",
+      status: "draft",
+      total_revenue: 75000,
+      total_billed: 0,
+      total_unbilled: 75000,
+      start_date: "2026-03-01",
+      end_date: "2026-12-31",
+    },
+  ];
+
+  it("computes totals", () => {
+    const result = analyzeContracts(contracts);
+    expect(result.totalContracts).toBe(3);
+    expect(result.totalRevenue).toBe(225000);
+    expect(result.totalRecognized).toBe(110000);
+    expect(result.totalRemaining).toBe(115000);
+  });
+
+  it("computes overall percent recognized", () => {
+    const result = analyzeContracts(contracts);
+    // 110000 / 225000 ≈ 48.89%
+    expect(result.percentRecognized).toBeCloseTo(48.89, 1);
+  });
+
+  it("computes per-contract percent recognized", () => {
+    const result = analyzeContracts(contracts);
+    expect(result.contracts[0].percentRecognized).toBe(60);
+    expect(result.contracts[1].percentRecognized).toBe(100);
+    expect(result.contracts[2].percentRecognized).toBe(0);
+  });
+
+  it("shapes contract fields", () => {
+    const result = analyzeContracts(contracts);
+    expect(result.contracts[0].clientName).toBe("Client A");
+    expect(result.contracts[0].recognized).toBe(60000);
+    expect(result.contracts[0].remaining).toBe(40000);
+  });
+
+  it("handles empty contracts", () => {
+    const result = analyzeContracts([]);
+    expect(result.totalContracts).toBe(0);
+    expect(result.totalRevenue).toBe(0);
+    expect(result.percentRecognized).toBeNull();
+  });
+
+  it("handles alternate field names (camelCase)", () => {
+    const result = analyzeContracts([
+      {
+        id: 99,
+        contract_name: "Alt Contract",
+        clientName: "Alt Client",
+        status: "active",
+        totalRevenue: 80000,
+        totalBilled: 40000,
+        totalUnbilled: 40000,
+        startDate: "2026-01-01",
+        endDate: "2026-12-31",
+      },
+    ]);
+    expect(result.contracts[0].name).toBe("Alt Contract");
+    expect(result.contracts[0].clientName).toBe("Alt Client");
+    expect(result.contracts[0].recognized).toBe(40000);
+    expect(result.contracts[0].startDate).toBe("2026-01-01");
+    expect(result.contracts[0].endDate).toBe("2026-12-31");
+  });
+
+  it("uses contract_value and recognized_revenue fallbacks", () => {
+    const result = analyzeContracts([
+      {
+        id: 100,
+        name: "Fallback",
+        client_name: "C",
+        status: "active",
+        contract_value: 60000,
+        recognized_revenue: 30000,
+      },
+    ]);
+    expect(result.totalRevenue).toBe(60000);
+    expect(result.totalRecognized).toBe(30000);
+    expect(result.totalRemaining).toBe(30000);
+  });
+});

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,357 @@
+// Pure data transformation helpers for Campfire MCP server.
+// No API calls — all functions take pre-fetched data and return shaped results.
+
+export interface DateRange {
+  dateFrom: string;
+  dateTo: string;
+}
+
+/** Get YYYY-MM-DD range for N months ago (full month). */
+export function getMonthRange(monthsAgo: number, now = new Date()): DateRange {
+  const d = new Date(now.getFullYear(), now.getMonth() - monthsAgo, 1);
+  const dateFrom = fmt(d);
+  const last = new Date(d.getFullYear(), d.getMonth() + 1, 0);
+  return { dateFrom, dateTo: fmt(last) };
+}
+
+/** Get YYYY-MM-DD range from Jan 1 of current year through today. */
+export function getCurrentYTDRange(now = new Date()): DateRange {
+  return {
+    dateFrom: `${now.getFullYear()}-01-01`,
+    dateTo: fmt(now),
+  };
+}
+
+/** Get YYYY-MM-DD range for the current month through today. */
+export function getCurrentMonthRange(now = new Date()): DateRange {
+  const first = new Date(now.getFullYear(), now.getMonth(), 1);
+  return { dateFrom: fmt(first), dateTo: fmt(now) };
+}
+
+function fmt(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+// --- Financial Snapshot ---
+
+export interface FinancialSnapshot {
+  period: string;
+  revenue: number;
+  expenses: number;
+  netIncome: number;
+  grossMarginPercent: number | null;
+  netMarginPercent: number | null;
+  cashPosition: number | null;
+  currentRatio: number | null;
+}
+
+/**
+ * Build a financial snapshot from raw Campfire statement data.
+ * Income statement data typically has sections with rows containing amounts.
+ * Balance sheet has assets/liabilities/equity sections.
+ */
+export function buildFinancialSnapshot(
+  incomeStatement: any,
+  balanceSheet: any,
+  cashFlow: any,
+  periodLabel: string,
+): FinancialSnapshot {
+  const revenue = extractTotal(incomeStatement, ["revenue", "income", "sales"]);
+  const cogs = extractTotal(incomeStatement, ["cost of goods", "cost of sales", "cogs", "cost of revenue"]);
+  const expenses = extractTotal(incomeStatement, ["expense", "operating expense", "total expense"]);
+  const netIncome = extractTotal(incomeStatement, ["net income", "net profit", "net earnings"]);
+
+  // Fallback: if netIncome isn't found as a line item, compute it
+  const computedNet = netIncome !== 0 ? netIncome : revenue - expenses;
+
+  const grossProfit = revenue - Math.abs(cogs);
+  const grossMarginPercent = revenue !== 0 ? round((grossProfit / revenue) * 100) : null;
+  const netMarginPercent = revenue !== 0 ? round((computedNet / revenue) * 100) : null;
+
+  // Balance sheet: cash and current ratio
+  const cash = extractTotal(balanceSheet, ["cash", "cash and cash equivalents", "bank"]);
+  const currentAssets = extractTotal(balanceSheet, ["current assets", "total current assets"]);
+  const currentLiabilities = extractTotal(balanceSheet, ["current liabilities", "total current liabilities"]);
+  const currentRatio = currentLiabilities !== 0 ? round(currentAssets / currentLiabilities) : null;
+
+  return {
+    period: periodLabel,
+    revenue,
+    expenses: Math.abs(expenses),
+    netIncome: computedNet,
+    grossMarginPercent,
+    netMarginPercent,
+    cashPosition: cash || null,
+    currentRatio,
+  };
+}
+
+// --- Burn Rate ---
+
+export interface BurnRateResult {
+  monthlyBurnAvg: number;
+  monthlyBurns: { month: string; burn: number }[];
+  trend: "increasing" | "decreasing" | "stable";
+  cashPosition: number | null;
+  runwayMonths: number | null;
+}
+
+/**
+ * Compute burn rate from an array of monthly income statements.
+ * Each entry: { label, data } where data is raw income statement response.
+ * Burn = revenue - expenses (negative = burning cash).
+ */
+export function computeBurnRate(
+  monthlyStatements: { label: string; data: any }[],
+  balanceSheet: any,
+): BurnRateResult {
+  const burns = monthlyStatements.map((m) => {
+    const rev = extractTotal(m.data, ["revenue", "income", "sales"]);
+    const exp = Math.abs(extractTotal(m.data, ["expense", "operating expense", "total expense"]));
+    return { month: m.label, burn: exp - rev };
+  });
+
+  const avgBurn = burns.length > 0
+    ? round(burns.reduce((s, b) => s + b.burn, 0) / burns.length)
+    : 0;
+
+  // Trend: compare first half average to second half average
+  let trend: "increasing" | "decreasing" | "stable" = "stable";
+  if (burns.length >= 3) {
+    const mid = Math.floor(burns.length / 2);
+    const firstHalf = burns.slice(0, mid).reduce((s, b) => s + b.burn, 0) / mid;
+    const secondHalf = burns.slice(mid).reduce((s, b) => s + b.burn, 0) / (burns.length - mid);
+    const diff = secondHalf - firstHalf;
+    if (diff > avgBurn * 0.1) trend = "increasing";
+    else if (diff < -avgBurn * 0.1) trend = "decreasing";
+  }
+
+  const cash = extractTotal(balanceSheet, ["cash", "cash and cash equivalents", "bank"]);
+  const runwayMonths = avgBurn > 0 && cash > 0 ? round(cash / avgBurn) : null;
+
+  return {
+    monthlyBurnAvg: avgBurn,
+    monthlyBurns: burns,
+    trend,
+    cashPosition: cash || null,
+    runwayMonths,
+  };
+}
+
+// --- Transaction enrichment ---
+
+export interface TransactionSummary {
+  totalTransactions: number;
+  totalDebits: number;
+  totalCredits: number;
+  byAccountType: Record<string, { count: number; debits: number; credits: number }>;
+  transactions: any[];
+}
+
+export function enrichTransactions(transactions: any[]): TransactionSummary {
+  let totalDebits = 0;
+  let totalCredits = 0;
+  const byAccountType: Record<string, { count: number; debits: number; credits: number }> = {};
+
+  const shaped = transactions.map((t: any) => {
+    const debit = Number(t.debit_amount || t.debit || 0);
+    const credit = Number(t.credit_amount || t.credit || 0);
+    totalDebits += debit;
+    totalCredits += credit;
+
+    const acctType = t.account_type || t.accountType || "Unknown";
+    if (!byAccountType[acctType]) {
+      byAccountType[acctType] = { count: 0, debits: 0, credits: 0 };
+    }
+    byAccountType[acctType].count++;
+    byAccountType[acctType].debits += debit;
+    byAccountType[acctType].credits += credit;
+
+    return {
+      id: t.id,
+      date: t.date || t.transaction_date,
+      description: t.description || t.memo,
+      accountName: t.account_name || t.accountName,
+      accountType: acctType,
+      vendorName: t.vendor_name || t.vendorName,
+      departmentName: t.department_name || t.departmentName,
+      debit,
+      credit,
+    };
+  });
+
+  return {
+    totalTransactions: transactions.length,
+    totalDebits: round(totalDebits),
+    totalCredits: round(totalCredits),
+    byAccountType,
+    transactions: shaped,
+  };
+}
+
+// --- Aging analysis ---
+
+export interface AgingSummary {
+  type: "ap" | "ar" | "combined";
+  totalOutstanding: number;
+  buckets: Record<string, { count: number; total: number }>;
+  criticalItems: any[];
+  items: any[];
+}
+
+export function analyzeAging(agingData: any[], agingType?: "ap" | "ar"): AgingSummary {
+  const buckets: Record<string, { count: number; total: number }> = {};
+  const criticalItems: any[] = [];
+  let totalOutstanding = 0;
+
+  const items = agingData.map((item: any) => {
+    const amount = Number(item.amount || item.balance || item.outstanding || 0);
+    const bucket = item.aging_bucket || item.bucket || item.age_bucket || categorizeDays(item.days_outstanding || item.days || 0);
+    totalOutstanding += amount;
+
+    if (!buckets[bucket]) buckets[bucket] = { count: 0, total: 0 };
+    buckets[bucket].count++;
+    buckets[bucket].total += amount;
+
+    const days = Number(item.days_outstanding || item.days || 0);
+    if (days >= 90 || bucket.includes("90")) {
+      criticalItems.push({
+        name: item.vendor_name || item.customer_name || item.name,
+        amount,
+        days,
+        bucket,
+      });
+    }
+
+    return {
+      name: item.vendor_name || item.customer_name || item.name,
+      amount,
+      bucket,
+      days,
+      invoiceNumber: item.invoice_number || item.reference,
+      dueDate: item.due_date,
+    };
+  });
+
+  // Round bucket totals
+  for (const b of Object.values(buckets)) {
+    b.total = round(b.total);
+  }
+
+  return {
+    type: agingType || "combined",
+    totalOutstanding: round(totalOutstanding),
+    buckets,
+    criticalItems,
+    items,
+  };
+}
+
+function categorizeDays(days: number): string {
+  if (days <= 30) return "0-30";
+  if (days <= 60) return "31-60";
+  if (days <= 90) return "61-90";
+  return "90+";
+}
+
+// --- Contract analysis ---
+
+export interface ContractSummary {
+  totalContracts: number;
+  totalRevenue: number;
+  totalRecognized: number;
+  totalRemaining: number;
+  percentRecognized: number | null;
+  contracts: any[];
+}
+
+export function analyzeContracts(contracts: any[]): ContractSummary {
+  let totalRevenue = 0;
+  let totalBilled = 0;
+  let totalUnbilled = 0;
+
+  const shaped = contracts.map((c: any) => {
+    const rev = Number(c.total_revenue || c.totalRevenue || c.contract_value || 0);
+    const billed = Number(c.total_billed || c.totalBilled || c.recognized_revenue || 0);
+    const unbilled = Number(c.total_unbilled || c.totalUnbilled || rev - billed);
+    totalRevenue += rev;
+    totalBilled += billed;
+    totalUnbilled += unbilled;
+
+    return {
+      id: c.id,
+      name: c.name || c.contract_name,
+      clientName: c.client_name || c.clientName,
+      status: c.status,
+      totalRevenue: rev,
+      recognized: billed,
+      remaining: unbilled,
+      percentRecognized: rev > 0 ? round((billed / rev) * 100) : 0,
+      startDate: c.start_date || c.startDate,
+      endDate: c.end_date || c.endDate,
+    };
+  });
+
+  return {
+    totalContracts: contracts.length,
+    totalRevenue: round(totalRevenue),
+    totalRecognized: round(totalBilled),
+    totalRemaining: round(totalUnbilled),
+    percentRecognized: totalRevenue > 0 ? round((totalBilled / totalRevenue) * 100) : null,
+    contracts: shaped,
+  };
+}
+
+// --- Utility ---
+
+/** Walk nested data looking for a matching section/row by name keywords. */
+function extractTotal(data: any, keywords: string[]): number {
+  if (!data) return 0;
+
+  // If data is an array of sections/rows
+  if (Array.isArray(data)) {
+    for (const item of data) {
+      const name = (item.name || item.label || item.title || item.account_name || "").toLowerCase();
+      if (keywords.some((k) => name.includes(k))) {
+        const val = item.total || item.amount || item.value || item.balance || 0;
+        return Number(val);
+      }
+      // Recurse into children/rows
+      const nested = item.children || item.rows || item.items || item.line_items;
+      if (nested) {
+        const found = extractTotal(nested, keywords);
+        if (found !== 0) return found;
+      }
+    }
+    return 0;
+  }
+
+  // If data is an object with sections
+  if (typeof data === "object") {
+    for (const key of Object.keys(data)) {
+      const keyLower = key.toLowerCase();
+      if (keywords.some((k) => keyLower.includes(k))) {
+        const val = data[key];
+        if (typeof val === "number") return val;
+        if (val?.total !== undefined) return Number(val.total);
+        if (val?.amount !== undefined) return Number(val.amount);
+        if (Array.isArray(val)) {
+          // Sum up the section
+          return val.reduce((s: number, r: any) => s + Number(r.amount || r.total || r.value || 0), 0);
+        }
+      }
+      // Recurse
+      if (typeof data[key] === "object" && data[key] !== null) {
+        const found = extractTotal(data[key], keywords);
+        if (found !== 0) return found;
+      }
+    }
+  }
+
+  return 0;
+}
+
+function round(n: number, decimals = 2): number {
+  const factor = 10 ** decimals;
+  return Math.round(n * factor) / factor;
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,12 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
-// We can't easily test the full server without mocking stdio,
-// but we can verify the module loads and exports are correct.
-
 describe("campfire-mcp-server", () => {
   it("should load without errors", async () => {
-    // Verify the MCP SDK is importable
     expect(McpServer).toBeDefined();
   });
 
@@ -20,6 +16,8 @@ describe("campfire-mcp-server", () => {
 
   it("should register all expected tools", async () => {
     const expectedTools = [
+      "get_financial_snapshot",
+      "get_burn_rate",
       "income_statement",
       "balance_sheet",
       "cash_flow_statement",
@@ -29,9 +27,7 @@ describe("campfire-mcp-server", () => {
       "get_aging",
       "get_contracts",
     ];
-    // Verify we expect 8 tools
-    expect(expectedTools).toHaveLength(8);
-    // Each tool name should be a non-empty string
+    expect(expectedTools).toHaveLength(10);
     for (const tool of expectedTools) {
       expect(tool).toBeTruthy();
       expect(typeof tool).toBe("string");

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    exclude: ["build/**", "node_modules/**"],
+    coverage: {
+      provider: "v8",
+      include: ["src/helpers.ts"],
+      thresholds: { statements: 80, branches: 80, functions: 80, lines: 80 },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- New `get_financial_snapshot` tool: revenue, expenses, margins, cash position, current ratio (current month + YTD)
- New `get_burn_rate` tool: monthly burn trend analysis, cash runway calculation
- Enriched `get_transactions`: summary with total debits/credits and breakdown by account type
- Enriched `get_aging`: bucket totals, total outstanding, 90+ day critical items highlighted
- Enriched `get_contracts`: recognized vs remaining revenue, per-contract percentages
- Pure helper functions in `src/helpers.ts` — all business logic unit-testable without HTTP mocking
- 42 unit tests with >88% branch coverage on helpers

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` — 45 tests pass
- [x] `npm run test:coverage` — >80% coverage threshold met
- [ ] MCP smoke test with live API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)