### PR TITLE
Add get_customers and trial_balance tools

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -26,8 +26,10 @@ describe("campfire-mcp-server", () => {
       "get_vendors",
       "get_aging",
       "get_contracts",
+      "get_customers",
+      "trial_balance",
     ];
-    expect(expectedTools).toHaveLength(10);
+    expect(expectedTools).toHaveLength(12);
     for (const tool of expectedTools) {
       expect(tool).toBeTruthy();
       expect(typeof tool).toBe("string");


### PR DESCRIPTION
## Summary
- `get_customers` — retrieves contract customers with shaped financial summaries: revenue, MRR, billed/unbilled/outstanding, contract counts
- `trial_balance` — generates trial balance grouped by account type with debit/credit totals and per-account net amounts
- Pure helper functions: `shapeCustomers`, `shapeTrialBalance`
- 59 tests, 89.88% branch coverage

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` — 59 tests pass
- [x] `npm run test:coverage` — >80% branch coverage
- [ ] Smoke test with live Campfire API key

🤖 Generated with [Claude Code](https://claude.com/claude-code)