### PR TITLE
Add CI and coverage badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,23 @@ jobs:
           node-version: 20
       - run: npm install
       - run: npm run build
-      - run: npm test
+      - run: npm run test:coverage
+
+      - name: Update coverage badge
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: |
+          COVERAGE=$(node -e "const c = require('./coverage/coverage-summary.json'); console.log(c.total.lines.pct)")
+          if [ $(echo "$COVERAGE >= 90" | bc) -eq 1 ]; then COLOR="brightgreen"
+          elif [ $(echo "$COVERAGE >= 80" | bc) -eq 1 ]; then COLOR="green"
+          elif [ $(echo "$COVERAGE >= 70" | bc) -eq 1 ]; then COLOR="yellowgreen"
+          elif [ $(echo "$COVERAGE >= 60" | bc) -eq 1 ]; then COLOR="yellow"
+          else COLOR="red"; fi
+          echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"${COLOR}\"}" > /tmp/coverage.json
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout --orphan badges-tmp
+          git rm -rf .
+          cp /tmp/coverage.json coverage.json
+          git add coverage.json
+          git commit -m "Update coverage badge: ${COVERAGE}%"
+          git push origin HEAD:badges --force

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # campfire-mcp-server
 
+[![CI](https://github.com/rocketsciencegg/campfire-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/rocketsciencegg/campfire-mcp-server/actions/workflows/ci.yml)
+![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/rocketsciencegg/campfire-mcp-server/badges/coverage.json)
+
 MCP server for Campfire — accounting and financial reporting.
 
 ## Tools

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/helpers.ts"],
+      reporter: ["text", "json-summary"],
       thresholds: { statements: 80, branches: 80, functions: 80, lines: 80 },
     },
   },


### PR DESCRIPTION
## Summary
- Add CI status badge and test coverage badge to README
- Update CI workflow to run `test:coverage` and push coverage.json to a `badges` branch on main pushes
- Add `json-summary` reporter to vitest config for coverage data extraction

## Test plan
- [ ] CI passes on this PR (build + tests)
- [ ] After merge, coverage badge step runs and creates `badges` branch with coverage.json
- [ ] Shields.io endpoint badge renders in README

🤖 Generated with [Claude Code](https://claude.com/claude-code)