### PR TITLE
Add budget tools (get_budgets, get_budget_details)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ MCP server for Campfire — accounting and financial reporting.
 | `get_customers` | Contract customers with financial summaries: revenue, MRR, billed/unbilled/outstanding, contract counts |
 | `get_invoices` | Invoices filtered by status (unpaid, paid, past_due, etc.), date range, client; summary with totals by status |
 | `trial_balance` | Trial balance by account type with debit/credit totals and per-account net amounts |
+| `get_budgets` | List budgets with entity/department names resolved, cadence breakdown summary |
+| `get_budget_details` | Single budget with all account allocations grouped by account type and department, with totals |
 
 ## Installation
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,7 +9,7 @@ describe("campfire-mcp-server", () => {
   it("should have correct server metadata", async () => {
     const server = new McpServer({
       name: "campfire-mcp-server",
-      version: "1.0.0",
+      version: "2.0.0",
     });
     expect(server).toBeDefined();
   });
@@ -29,8 +29,10 @@ describe("campfire-mcp-server", () => {
       "get_customers",
       "trial_balance",
       "get_invoices",
+      "get_budgets",
+      "get_budget_details",
     ];
-    expect(expectedTools).toHaveLength(13);
+    expect(expectedTools).toHaveLength(15);
     for (const tool of expectedTools) {
       expect(tool).toBeTruthy();
       expect(typeof tool).toBe("string");


### PR DESCRIPTION
## Summary
- `get_budgets` — list/search budgets with entity/department names resolved, cadence breakdown
- `get_budget_details` — single budget + all account allocations grouped by account type and department, with totals
- Helper functions in `helpers.ts` with full test coverage (17 new tests, 84 total)
- README and index.test.ts updated

## Test plan
- [x] `npm run build` compiles clean
- [x] `npm test` — 84/84 tests pass
- [x] New helper tests cover: empty lists, missing fields, tag extraction, department grouping, lineage parsing

🤖 Generated with [Claude Code](https://claude.com/claude-code)