### PR TITLE
Add uncategorized transactions + bills tools, fix broken API calls (v2.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ MCP server for Campfire — accounting and financial reporting.
 | `trial_balance` | Trial balance by account type with debit/credit totals and per-account net amounts |
 | `get_budgets` | List budgets with entity/department names resolved, cadence breakdown summary |
 | `get_budget_details` | Single budget with all account allocations grouped by account type and department, with totals |
+| `get_uncategorized_transactions` | Uncategorized transactions grouped by vendor, with AI suggestions and matching hints |
+| `get_bills` | Bills filtered by status (unpaid, open, past_due, etc.), vendor, date range; summary with totals by status and vendor |
 
 ## Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "campfire-mcp-server",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "campfire-mcp-server",
-      "version": "1.0.0",
+      "version": "2.1.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
         "campfire-typescript-sdk": "github:rocketsciencegg/campfire-typescript-sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "campfire-mcp-server",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "type": "module",
   "bin": {
     "campfire-mcp-server": "./build/index.js"

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,7 +9,7 @@ describe("campfire-mcp-server", () => {
   it("should have correct server metadata", async () => {
     const server = new McpServer({
       name: "campfire-mcp-server",
-      version: "2.0.0",
+      version: "2.1.0",
     });
     expect(server).toBeDefined();
   });
@@ -31,8 +31,10 @@ describe("campfire-mcp-server", () => {
       "get_invoices",
       "get_budgets",
       "get_budget_details",
+      "get_uncategorized_transactions",
+      "get_bills",
     ];
-    expect(expectedTools).toHaveLength(15);
+    expect(expectedTools).toHaveLength(17);
     for (const tool of expectedTools) {
       expect(tool).toBeTruthy();
       expect(typeof tool).toBe("string");


### PR DESCRIPTION
## Summary
- Add `get_uncategorized_transactions` tool — uncategorized transactions grouped by vendor, with AI suggestions and matching hints
- Add `get_bills` tool — bills filtered by status, vendor, date range; summary with totals by status and vendor
- Fix 7 pre-existing broken tools that used non-existent SDK method names (hidden by `as any` casts): `get_transactions`, `get_accounts`, `get_vendors`, `get_aging`, `get_contracts`, `get_budgets`, `get_budget_details`
- Bump version to 2.1.0

## Test plan
- [x] `npm run build` compiles without errors
- [x] `npm test` — 108 tests pass (105 helper tests + 3 index tests)
- [x] `npm run test:coverage` — 100% statements, 100% lines, 90.76% branches
- [x] Live smoke test: all 16 API calls verified against production Campfire API (15 pass, 1 skipped due to no budget data in account)
- [ ] Tag `v2.1.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)