### PR TITLE
Add bump recipe, harden .gitignore, patch to v2.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ build/
 .DS_Store
 *.log
 coverage/
-.env
+.env*
+.dev.vars

--- a/justfile
+++ b/justfile
@@ -25,6 +25,18 @@ test:
 # Build and test
 check: build test
 
+# Bump version (major, minor, or patch) across all files
+bump level="patch":
+    #!/usr/bin/env bash
+    set -euo pipefail
+    new=$(npm version "{{level}}" --no-git-tag-version | tr -d 'v')
+    echo "Bumped to $new"
+    # src/index.ts — McpServer version
+    sed -i '' -E "s/version: \"[0-9]+\.[0-9]+\.[0-9]+\"/version: \"$new\"/" src/index.ts
+    # README.md — version tags in npx install URLs
+    sed -i '' -E "s/#v[0-9]+\.[0-9]+\.[0-9]+/#v$new/g" README.md
+    echo "Updated: package.json, src/index.ts, README.md → $new"
+
 # Clean build artifacts
 clean:
     rm -rf build coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "campfire-mcp-server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "campfire-mcp-server",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
         "campfire-typescript-sdk": "github:rocketsciencegg/campfire-typescript-sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "campfire-mcp-server",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "type": "module",
   "bin": {
     "campfire-mcp-server": "./build/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,7 @@ function errorResult(toolName: string, err: unknown) {
 function createServer() {
 const server = new McpServer({
   name: "campfire-mcp-server",
-  version: "2.1.0",
+  version: "2.1.1",
 });
 
 server.registerTool(


### PR DESCRIPTION
## Summary
- Add `just bump` recipe (accepts `major`, `minor`, `patch`) to update version across `package.json`, `src/index.ts`, and README in one command
- Harden `.gitignore`: broaden `.env` to `.env*`, add `.dev.vars`
- Patch bump to v2.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)