### PR TITLE
Add credit memo tools (#26)

### DIFF
--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -17,6 +17,7 @@ import {
   shapeBills,
   shapeDepartments,
   shapeAccounts,
+  shapeCreditMemos,
 } from "./helpers.js";
 
 // --- Date helpers ---
@@ -1685,5 +1686,138 @@ describe("shapeAccounts", () => {
     expect(a.parentId).toBeNull();
     expect(a.balance).toBeNull();
     expect(a.description).toBeNull();
+  });
+});
+
+// --- Credit memo shaping ---
+
+describe("shapeCreditMemos", () => {
+  const creditMemos = [
+    {
+      id: 1,
+      credit_memo_number: "CM-001",
+      credit_memo_date: "2026-01-15",
+      client_name: "Acme Corp",
+      entity_name: "US Entity",
+      contract_name: "Contract A",
+      application_status: "open",
+      total_amount: 5000,
+      amount_used: 0,
+      amount_remaining: 5000,
+      currency: "USD",
+      message_on_credit_memo: "Refund for Q4",
+      lines: [{ id: 1 }, { id: 2 }],
+    },
+    {
+      id: 2,
+      credit_memo_number: "CM-002",
+      credit_memo_date: "2026-02-01",
+      client_name: "Acme Corp",
+      entity_name: "US Entity",
+      application_status: "used",
+      total_amount: 3000,
+      amount_used: 3000,
+      amount_remaining: 0,
+      currency: "USD",
+      lines: [{ id: 3 }],
+    },
+    {
+      id: 3,
+      credit_memo_number: "CM-003",
+      credit_memo_date: "2026-02-10",
+      client_name: "Beta Inc",
+      entity_name: "UK Entity",
+      application_status: "partially_used",
+      total_amount: 8000,
+      amount_used: 2000,
+      amount_remaining: 6000,
+      currency: "GBP",
+      lines: [{ id: 4 }, { id: 5 }, { id: 6 }],
+    },
+  ];
+
+  it("computes aggregate totals", () => {
+    const result = shapeCreditMemos(creditMemos);
+    expect(result.totalCreditMemos).toBe(3);
+    expect(result.totalAmount).toBe(16000);
+    expect(result.totalUsed).toBe(5000);
+    expect(result.totalRemaining).toBe(11000);
+  });
+
+  it("groups by status", () => {
+    const result = shapeCreditMemos(creditMemos);
+    expect(result.byStatus["open"].count).toBe(1);
+    expect(result.byStatus["open"].total).toBe(5000);
+    expect(result.byStatus["used"].count).toBe(1);
+    expect(result.byStatus["used"].total).toBe(3000);
+    expect(result.byStatus["partially_used"].count).toBe(1);
+    expect(result.byStatus["partially_used"].total).toBe(8000);
+  });
+
+  it("shapes individual credit memo fields", () => {
+    const result = shapeCreditMemos(creditMemos);
+    const cm = result.creditMemos[0];
+    expect(cm.id).toBe(1);
+    expect(cm.creditMemoNumber).toBe("CM-001");
+    expect(cm.creditMemoDate).toBe("2026-01-15");
+    expect(cm.clientName).toBe("Acme Corp");
+    expect(cm.entityName).toBe("US Entity");
+    expect(cm.contractName).toBe("Contract A");
+    expect(cm.status).toBe("open");
+    expect(cm.totalAmount).toBe(5000);
+    expect(cm.amountUsed).toBe(0);
+    expect(cm.amountRemaining).toBe(5000);
+    expect(cm.currency).toBe("USD");
+    expect(cm.message).toBe("Refund for Q4");
+    expect(cm.lineCount).toBe(2);
+  });
+
+  it("handles empty list", () => {
+    const result = shapeCreditMemos([]);
+    expect(result.totalCreditMemos).toBe(0);
+    expect(result.totalAmount).toBe(0);
+    expect(result.totalUsed).toBe(0);
+    expect(result.totalRemaining).toBe(0);
+    expect(result.byStatus).toEqual({});
+    expect(result.creditMemos).toHaveLength(0);
+  });
+
+  it("handles camelCase field names", () => {
+    const result = shapeCreditMemos([
+      {
+        id: 10,
+        creditMemoNumber: "CM-010",
+        creditMemoDate: "2026-03-01",
+        clientName: "Gamma LLC",
+        entityName: "US Entity",
+        applicationStatus: "voided",
+        totalAmount: 1000,
+        amountUsed: 0,
+        amountRemaining: 0,
+        messageOnCreditMemo: "Voided",
+      },
+    ]);
+    const cm = result.creditMemos[0];
+    expect(cm.creditMemoNumber).toBe("CM-010");
+    expect(cm.clientName).toBe("Gamma LLC");
+    expect(cm.status).toBe("voided");
+    expect(cm.message).toBe("Voided");
+  });
+
+  it("defaults missing optional fields", () => {
+    const result = shapeCreditMemos([{ id: 20 }]);
+    const cm = result.creditMemos[0];
+    expect(cm.creditMemoNumber).toBeNull();
+    expect(cm.creditMemoDate).toBeNull();
+    expect(cm.clientName).toBeNull();
+    expect(cm.entityName).toBeNull();
+    expect(cm.contractName).toBeNull();
+    expect(cm.status).toBe("unknown");
+    expect(cm.totalAmount).toBe(0);
+    expect(cm.amountUsed).toBe(0);
+    expect(cm.amountRemaining).toBe(0);
+    expect(cm.currency).toBeNull();
+    expect(cm.message).toBeNull();
+    expect(cm.lineCount).toBe(0);
   });
 });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -832,6 +832,70 @@ export function shapeAccounts(accounts: any[]): AccountSummary {
   };
 }
 
+// --- Credit memo shaping ---
+
+export interface CreditMemoSummary {
+  totalCreditMemos: number;
+  totalAmount: number;
+  totalUsed: number;
+  totalRemaining: number;
+  byStatus: Record<string, { count: number; total: number }>;
+  creditMemos: any[];
+}
+
+export function shapeCreditMemos(creditMemos: any[]): CreditMemoSummary {
+  let totalAmount = 0;
+  let totalUsed = 0;
+  let totalRemaining = 0;
+  const byStatus: Record<string, { count: number; total: number }> = {};
+
+  const shaped = creditMemos.map((cm: any) => {
+    const amount = Number(cm.total_amount ?? cm.totalAmount ?? 0);
+    const used = Number(cm.amount_used ?? cm.amountUsed ?? 0);
+    const remaining = Number(cm.amount_remaining ?? cm.amountRemaining ?? 0);
+    totalAmount += amount;
+    totalUsed += used;
+    totalRemaining += remaining;
+
+    const status = cm.application_status ?? cm.applicationStatus ?? "unknown";
+    if (!byStatus[status]) byStatus[status] = { count: 0, total: 0 };
+    byStatus[status].count++;
+    byStatus[status].total += amount;
+
+    const lines = cm.lines ?? [];
+
+    return {
+      id: cm.id,
+      creditMemoNumber: cm.credit_memo_number ?? cm.creditMemoNumber ?? null,
+      creditMemoDate: cm.credit_memo_date ?? cm.creditMemoDate ?? null,
+      clientName: cm.client_name ?? cm.clientName ?? null,
+      entityName: cm.entity_name ?? cm.entityName ?? null,
+      contractName: cm.contract_name ?? cm.contractName ?? null,
+      status,
+      totalAmount: amount,
+      amountUsed: used,
+      amountRemaining: remaining,
+      currency: cm.currency ?? null,
+      message: cm.message_on_credit_memo ?? cm.messageOnCreditMemo ?? null,
+      lineCount: Array.isArray(lines) ? lines.length : 0,
+    };
+  });
+
+  // Round status bucket totals
+  for (const b of Object.values(byStatus)) {
+    b.total = round(b.total);
+  }
+
+  return {
+    totalCreditMemos: creditMemos.length,
+    totalAmount: round(totalAmount),
+    totalUsed: round(totalUsed),
+    totalRemaining: round(totalRemaining),
+    byStatus,
+    creditMemos: shaped,
+  };
+}
+
 // --- Department shaping ---
 
 export interface DepartmentSummary {

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ import {
   shapeBills,
   shapeDepartments,
   shapeAccounts,
+  shapeCreditMemos,
 } from "./helpers.js";
 
 // Campfire uses apiKey auth with "Token <key>" format
@@ -823,6 +824,46 @@ server.registerTool(
       };
     } catch (err) {
       return errorResult("get_bills", err);
+    }
+  }
+);
+
+// --- CREDIT MEMO TOOLS ---
+
+server.registerTool(
+  "get_credit_memos",
+  {
+    description:
+      "Retrieve credit memos with filtering by status, date range, client, and search query. Returns summary with totals, amount used/remaining, and breakdown by status. Status values: open, partially_used, used, voided.",
+    inputSchema: {
+      status: z.enum(["open", "partially_used", "used", "voided"]).optional()
+        .describe("Filter by status: open, partially_used, used, voided"),
+      startDate: z.string().optional().describe("Filter credit memos on or after this date (YYYY-MM-DD)"),
+      endDate: z.string().optional().describe("Filter credit memos on or before this date (YYYY-MM-DD)"),
+      clientId: z.number().optional().describe("Filter by client ID"),
+      q: z.string().optional().describe("Search credit memo numbers, messages, client names"),
+      limit: z.number().optional().describe("Max results (default: 50)"),
+      offset: z.number().optional().describe("Pagination offset"),
+    },
+  },
+  async ({ status, startDate, endDate, clientId, q, limit, offset }) => {
+    try {
+      const resp = await (arApi as any).coaApiV1CreditMemoList({
+        client: clientId ? [clientId] : undefined,
+        endDate,
+        limit: limit ?? 50,
+        offset: offset ?? 0,
+        q,
+        startDate,
+        status,
+      });
+      const raw = Array.isArray(resp.data) ? resp.data : resp.data?.results || [];
+      const result = shapeCreditMemos(raw);
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }],
+      };
+    } catch (err) {
+      return errorResult("get_credit_memos", err);
     }
   }
 );

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -32,6 +32,7 @@ import {
   shapeBills,
   shapeDepartments,
   shapeAccounts,
+  shapeCreditMemos,
   getCurrentMonthRange,
   getCurrentYTDRange,
   getMonthRange,
@@ -616,7 +617,59 @@ describe("get_invoices", () => {
   });
 });
 
-// ─── 15. get_budgets ───────────────────────────────────────────────────────
+// ─── 15. get_credit_memos ─────────────────────────────────────────────────
+
+describe("get_credit_memos", () => {
+  it("returns credit memos with shaped output", async () => {
+    const resp = await (arApi as any).coaApiV1CreditMemoList({
+      limit: 10,
+      offset: 0,
+    });
+    const raw = extractRaw(resp);
+    expect(Array.isArray(raw)).toBe(true);
+
+    const result = shapeCreditMemos(raw);
+    expect(typeof result.totalCreditMemos).toBe("number");
+    expect(typeof result.totalAmount).toBe("number");
+    expect(typeof result.totalUsed).toBe("number");
+    expect(typeof result.totalRemaining).toBe("number");
+    expect(result).toHaveProperty("byStatus");
+  });
+
+  it("filters by status", async () => {
+    const resp = await (arApi as any).coaApiV1CreditMemoList({
+      status: "open",
+      limit: 5,
+      offset: 0,
+    });
+    const raw = extractRaw(resp);
+    expect(Array.isArray(raw)).toBe(true);
+    for (const cm of raw) {
+      expect(cm.application_status).toBe("open");
+    }
+  });
+
+  it("filters by date range", async () => {
+    const resp = await (arApi as any).coaApiV1CreditMemoList({
+      startDate: "2025-01-01",
+      endDate: "2025-12-31",
+      limit: 5,
+      offset: 0,
+    });
+    expect(Array.isArray(extractRaw(resp))).toBe(true);
+  });
+
+  it("supports search (q param)", async () => {
+    const resp = await (arApi as any).coaApiV1CreditMemoList({
+      q: "CM",
+      limit: 5,
+      offset: 0,
+    });
+    expect(Array.isArray(extractRaw(resp))).toBe(true);
+  });
+});
+
+// ─── 16. get_budgets ───────────────────────────────────────────────────────
 
 describe("get_budgets", () => {
   it("returns budget list", async () => {


### PR DESCRIPTION
## Summary
- New `get_credit_memos` tool exposing the Campfire credit memo API (`coaApiV1CreditMemoList`)
- Supports filtering by: `status` (open/partially_used/used/voided), `startDate`, `endDate`, `clientId`, `q` (search)
- New `shapeCreditMemos()` helper returns compact summary with totals, amount used/remaining, and breakdown by status
- Each credit memo includes: id, number, date, client, entity, contract, status, amounts, currency, message, line count

## Test plan
- [x] Unit tests pass (121/121) — includes 6 new `shapeCreditMemos` tests
- [x] Integration tests pass (42/42) against live Campfire API
- [x] New integration tests: list credit memos, filter by status, filter by date range, search

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)