### PR TITLE
Add tax/net amounts to get_invoices (#23)

### DIFF
--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -627,6 +627,10 @@ describe("shapeInvoices", () => {
       pastDueDays: 0,
       currency: "USD",
       paymentTermName: "Net 30",
+      lines: [
+        { amount: 8000, tax: 1600, description: "Consulting" },
+        { amount: 400, tax: 0, description: "Expenses" },
+      ],
     },
     {
       id: 102,
@@ -644,6 +648,9 @@ describe("shapeInvoices", () => {
       pastDueDays: 0,
       currency: "USD",
       paymentTermName: "Net 30",
+      lines: [
+        { amount: 4166.67, tax: 833.33, description: "Services" },
+      ],
     },
     {
       id: 103,
@@ -660,6 +667,9 @@ describe("shapeInvoices", () => {
       pastDueDays: 69,
       currency: "USD",
       paymentTermName: "Net 30",
+      lines: [
+        { amount: 6666.67, tax: 1333.33, description: "Consulting" },
+      ],
     },
   ];
 
@@ -669,6 +679,29 @@ describe("shapeInvoices", () => {
     expect(result.totalAmount).toBe(23000);
     expect(result.totalPaid).toBe(5000);
     expect(result.totalDue).toBe(18000);
+  });
+
+  it("computes net and tax amounts from line items", () => {
+    const result = shapeInvoices(invoices);
+    // INV-001: net=8400, tax=1600; INV-002: net=4166.67, tax=833.33; INV-003: net=6666.67, tax=1333.33
+    expect(result.totalNetAmount).toBe(19233.34);
+    expect(result.totalTaxAmount).toBe(3766.66);
+
+    // Per-invoice
+    expect(result.invoices[0].netAmount).toBe(8400);
+    expect(result.invoices[0].taxAmount).toBe(1600);
+    expect(result.invoices[1].netAmount).toBe(4166.67);
+    expect(result.invoices[1].taxAmount).toBe(833.33);
+    expect(result.invoices[2].netAmount).toBe(6666.67);
+    expect(result.invoices[2].taxAmount).toBe(1333.33);
+  });
+
+  it("handles invoices without line items (zero net/tax)", () => {
+    const result = shapeInvoices([{ id: 999, totalAmount: 5000, amountDue: 5000, status: "unpaid" }]);
+    expect(result.invoices[0].netAmount).toBe(0);
+    expect(result.invoices[0].taxAmount).toBe(0);
+    expect(result.totalNetAmount).toBe(0);
+    expect(result.totalTaxAmount).toBe(0);
   });
 
   it("groups by status", () => {
@@ -736,6 +769,8 @@ describe("shapeInvoices", () => {
     const result = shapeInvoices([]);
     expect(result.totalInvoices).toBe(0);
     expect(result.totalAmount).toBe(0);
+    expect(result.totalNetAmount).toBe(0);
+    expect(result.totalTaxAmount).toBe(0);
     expect(result.totalPaid).toBe(0);
     expect(result.totalDue).toBe(0);
     expect(result.invoices).toHaveLength(0);

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -361,6 +361,8 @@ export function shapeCustomers(customers: any[]): CustomerSummary {
 export interface InvoiceSummary {
   totalInvoices: number;
   totalAmount: number;
+  totalNetAmount: number;
+  totalTaxAmount: number;
   totalPaid: number;
   totalDue: number;
   byStatus: Record<string, { count: number; totalAmount: number; totalDue: number }>;
@@ -369,6 +371,8 @@ export interface InvoiceSummary {
 
 export function shapeInvoices(invoices: any[]): InvoiceSummary {
   let totalAmount = 0;
+  let totalNetAmount = 0;
+  let totalTaxAmount = 0;
   let totalPaid = 0;
   let totalDue = 0;
   const byStatus: Record<string, { count: number; totalAmount: number; totalDue: number }> = {};
@@ -380,6 +384,19 @@ export function shapeInvoices(invoices: any[]): InvoiceSummary {
     totalAmount += amount;
     totalPaid += paid;
     totalDue += due;
+
+    // Compute net and tax amounts from line items
+    const lines = inv.lines ?? inv.line_items ?? inv.lineItems ?? [];
+    let netAmount = 0;
+    let taxAmount = 0;
+    if (Array.isArray(lines) && lines.length > 0) {
+      for (const line of lines) {
+        netAmount += Number(line.amount ?? 0);
+        taxAmount += Number(line.tax ?? 0);
+      }
+    }
+    totalNetAmount += netAmount;
+    totalTaxAmount += taxAmount;
 
     const status = inv.status ?? "unknown";
     if (!byStatus[status]) {
@@ -399,6 +416,8 @@ export function shapeInvoices(invoices: any[]): InvoiceSummary {
       invoiceDate: inv.invoiceDate ?? inv.invoice_date,
       dueDate: inv.dueDate ?? inv.due_date,
       totalAmount: amount,
+      netAmount: round(netAmount),
+      taxAmount: round(taxAmount),
       amountDue: due,
     };
     if (paid > 0) shaped.amountPaid = paid;
@@ -416,6 +435,8 @@ export function shapeInvoices(invoices: any[]): InvoiceSummary {
   return {
     totalInvoices: invoices.length,
     totalAmount: round(totalAmount),
+    totalNetAmount: round(totalNetAmount),
+    totalTaxAmount: round(totalTaxAmount),
     totalPaid: round(totalPaid),
     totalDue: round(totalDue),
     byStatus,

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -435,7 +435,7 @@ describe("get_customers", () => {
 // ─── 14. get_invoices ──────────────────────────────────────────────────────
 
 describe("get_invoices", () => {
-  it("returns shaped invoices with compact fields", async () => {
+  it("returns shaped invoices with compact fields and tax/net amounts", async () => {
     const resp = await (arApi as any).coaApiV1InvoiceList({
       limit: 5,
       offset: 0,
@@ -446,6 +446,8 @@ describe("get_invoices", () => {
     const result = shapeInvoices(raw);
     expect(typeof result.totalInvoices).toBe("number");
     expect(typeof result.totalAmount).toBe("number");
+    expect(typeof result.totalNetAmount).toBe("number");
+    expect(typeof result.totalTaxAmount).toBe("number");
     expect(typeof result.totalDue).toBe("number");
 
     // Verify compact shape — removed fields should not appear
@@ -455,7 +457,11 @@ describe("get_invoices", () => {
       expect(inv).toHaveProperty("invoiceNumber");
       expect(inv).toHaveProperty("status");
       expect(inv).toHaveProperty("totalAmount");
+      expect(inv).toHaveProperty("netAmount");
+      expect(inv).toHaveProperty("taxAmount");
       expect(inv).toHaveProperty("amountDue");
+      expect(typeof inv.netAmount).toBe("number");
+      expect(typeof inv.taxAmount).toBe("number");
       // These were removed for compactness
       expect(inv.contractName).toBeUndefined();
       expect(inv.entityName).toBeUndefined();


### PR DESCRIPTION
## Summary
- Computes `netAmount` (sum of `line.amount`) and `taxAmount` (sum of `line.tax`) per invoice from line items in the API response
- Adds `totalNetAmount` and `totalTaxAmount` to the invoice summary
- Enables reconciliation between systems that report net vs gross amounts without hitting the raw API

## Example output
Each invoice now includes:
```json
{
  "totalAmount": 12000,
  "netAmount": 10000,
  "taxAmount": 2000,
  "amountDue": 12000
}
```

Summary includes:
```json
{
  "totalAmount": 120000,
  "totalNetAmount": 100000,
  "totalTaxAmount": 20000,
  "totalPaid": 80000,
  "totalDue": 40000
}
```

## Test plan
- [x] Unit tests pass (117/117) — includes 3 new tax/net amount tests
- [x] Integration tests pass (38/38) against live Campfire API
- [x] Integration test verifies `netAmount` and `taxAmount` fields are present and numeric

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)