### PR TITLE
Add get_transaction tool (single transaction by ID)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -284,6 +284,63 @@ server.registerTool(
 // --- ENRICHED EXISTING TOOLS ---
 
 server.registerTool(
+  "get_transaction",
+  {
+    description:
+      "Retrieve a single transaction by ID with full detail: account, vendor, department, journal entry, amounts (debit/credit in native and book currencies), dates, tags, and linked invoices/bills.",
+    inputSchema: {
+      id: z.number().describe("The transaction ID"),
+    },
+  },
+  async ({ id }) => {
+    try {
+      const resp = await (coreAccountingApi as any).coaApiTransactionRetrieve2({ id });
+      const t = resp.data;
+
+      const shaped = {
+        id: t.id,
+        postedAt: t.posted_at,
+        accountName: t.account_name,
+        accountNumber: t.account_number,
+        accountType: t.account_type,
+        accountSubtype: t.account_subtype,
+        vendorName: t.vendor_name,
+        departmentName: t.department_name,
+        entityName: t.entity_name,
+        journalMemo: t.journal_memo,
+        journalType: t.journal_type_name ?? t.journal_type,
+        debitAmount: t.debit_amount != null ? Number(t.debit_amount) : null,
+        creditAmount: t.credit_amount != null ? Number(t.credit_amount) : null,
+        amount: Number(t.amount ?? 0),
+        currency: t.currency,
+        exchangeRate: t.exchange_rate,
+        merchantName: t.merchant_name,
+        bankDescription: t.bank_description,
+        note: t.note,
+        invoiceId: t.invoice_id || null,
+        invoiceNumber: t.invoice_number || null,
+        billId: t.bill_id || null,
+        billNumber: t.bill_number || null,
+        tags: Array.isArray(t.tags) ? t.tags.map((tag: any) => tag.name ?? tag) : [],
+        needsReview: t.needs_review ?? false,
+        hasMatches: t.has_matches ?? false,
+        suggestedAccountName: t.suggested_account_name,
+        suggestedAccountNumber: t.suggested_account_number,
+        balanceAfterTransaction: t.balance_after_transaction,
+        createdAt: t.created_at,
+        lastModifiedAt: t.last_modified_at,
+      };
+
+      return {
+        content: [{ type: "text" as const, text: JSON.stringify(shaped, null, 2) }],
+      };
+    } catch (err) {
+      return errorResult("get_transaction", err);
+    }
+  }
+);
+
+server.registerTool(
   "get_transactions",
   {
     description:

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -260,7 +260,32 @@ describe("get_burn_rate", () => {
   });
 });
 
-// ─── 8. get_transactions ───────────────────────────────────────────────────
+// ─── 8. get_transaction (single) ──────────────────────────────────────────
+
+describe("get_transaction", () => {
+  it("retrieves a single transaction by ID with full detail", async () => {
+    // First get a transaction ID from the list
+    const listResp = await (coreAccountingApi as any).coaApiTransactionRetrieve({
+      params: { limit: 1 },
+    });
+    const raw = extractRaw(listResp);
+    if (raw.length === 0) return;
+
+    const txnId = raw[0].id;
+    const resp = await (coreAccountingApi as any).coaApiTransactionRetrieve2({ id: txnId });
+    const t = resp.data;
+
+    expect(t).toBeDefined();
+    expect(t.id).toBe(txnId);
+    expect(t).toHaveProperty("account_name");
+    expect(t).toHaveProperty("account_type");
+    expect(t).toHaveProperty("posted_at");
+    expect(t).toHaveProperty("debit_amount");
+    expect(t).toHaveProperty("credit_amount");
+  });
+});
+
+// ─── 9. get_transactions ───────────────────────────────────────────────────
 
 describe("get_transactions", () => {
   it("returns transactions with default limit", async () => {


### PR DESCRIPTION
## Summary
- New `get_transaction` tool for looking up a single transaction by ID using `coaApiTransactionRetrieve2(id)`
- Returns full transaction detail: account info, vendor, department, journal entry, amounts (native/book currencies), linked invoices/bills, tags, AI suggestions
- Useful for drilling into specific transactions found via `get_transactions`

## Test plan
- [x] Unit tests pass (115/115)
- [x] Integration tests pass (39/39) against live Campfire API
- [x] New integration test: fetches a transaction ID from the list, then retrieves full detail by ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)