### PR TITLE
Fix package-lock.json version to match v2.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "campfire-mcp-server",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "campfire-mcp-server",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
         "campfire-typescript-sdk": "github:rocketsciencegg/campfire-typescript-sdk",


### PR DESCRIPTION
## Summary
- Sync package-lock.json version from 2.3.0 → 2.4.0 (missed in #44)

🤖 Generated with [Claude Code](https://claude.com/claude-code)