### PR TITLE
Bump version to v2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "campfire-mcp-server",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "campfire-mcp-server",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.5",
         "campfire-typescript-sdk": "github:rocketsciencegg/campfire-typescript-sdk",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "campfire-mcp-server",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "type": "module",
   "bin": {
     "campfire-mcp-server": "./build/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ const SERVER_INSTRUCTIONS = `Campfire identifier rules (applies to every tool):
 function createServer() {
 const server = new McpServer({
   name: "campfire-mcp-server",
-  version: "2.4.0",
+  version: "2.5.0",
 }, {
   instructions: SERVER_INSTRUCTIONS,
 });


### PR DESCRIPTION
## Summary
- Minor bump — #48 added 6 new fetch-by-id tools and a shared MCP ID vocabulary (new features, backwards-compatible with existing tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)